### PR TITLE
Checkbox fix- validate for "go" button on Results1.php

### DIFF
--- a/Results1.php
+++ b/Results1.php
@@ -127,9 +127,13 @@ function enableDisable()
     for (var index = 0; index < atLeastOne.length; index++) 
     { 
         // If at least one required box is checked, disabled becomes false
-        // When it becomes false, it stays false
-        // Boolean logic, yo
-        disabled = disabled && !(atLeastOne[index].checked);
+        disabled = !(atLeastOne[index].checked);
+
+        // Break on first checked box
+        if (disabled == false)
+        {
+            break;
+        }
     } 
     
     // Disable the submit button based on results
@@ -142,7 +146,6 @@ var inputs = document.querySelectorAll("input[requiredAtLeastOne]");
 // Add an event listener to each which calls the enableDisable function
 for (var index = 0; index < inputs.length; index++) 
 { 
-    // Trust me, you need to do it this way
     inputs[index].addEventListener("click", function() { enableDisable(); });
 }
 </script>

--- a/Results1.php
+++ b/Results1.php
@@ -80,7 +80,8 @@ $COMMON = new Common($debug); // common methods
 print($tfNameF . " " . $tfNameL);
 print("<br>" . $tfId);
 	print("<div class = 'showButton'>");
-		print("Show Appointments: <input type='submit' style='height: 5%; width: 25%;' value='GO'>"); 
+        # Disable until at least one of the "at least one required" checkboxes is checked
+		print("Show Appointments: <input type='submit' style='height: 5%; width: 25%;' value='GO' id='btnGo' disabled>"); 
 	print("</div>");
 print("<br><br><hr>");
 
@@ -99,8 +100,10 @@ for($majorNum = 0; $majorNum < count($cbMajors); $majorNum++) {
 	print("<h2>");
 
 	print("<div class = 'apptType'>");
-		print("Individual Advising: <input type='checkbox' style='height: 20px; width: 20px;' name='chkbIndividual[]' value='$selectedChoice'><br>"); 
-		print("Group Advising: <input type='checkbox' style='height: 20px; width: 20px;' name='chkbGroup[]' value='$selectedChoice'><br>"); 
+
+        # The requiredAtLeastOne attribute makes it easy for the javascript to access all the "at least one required" checkboxes
+		print("Individual Advising: <input type='checkbox' style='height: 20px; width: 20px;' name='chkbIndividual[]' value='$selectedChoice' requiredAtLeastOne><br>"); 
+		print("Group Advising: <input type='checkbox' style='height: 20px; width: 20px;' name='chkbGroup[]' value='$selectedChoice' requiredAtLeastOne><br>"); 
 	print("</div>");
 	print("</h2>");
 
@@ -108,6 +111,44 @@ for($majorNum = 0; $majorNum < count($cbMajors); $majorNum++) {
 	
 }
 
+?>
+
+<!-- Submit validator script -->
+<script type="text/javascript">
+
+// Create the function that enables and disables the submit button 
+function enableDisable() 
+{ 
+    // Initially set disabled to true
+    var disabled = true; 
+    // Get all "at least one required" elements
+    var atLeastOne = document.querySelectorAll("input[requiredAtLeastOne]"); 
+    
+    for (var index = 0; index < atLeastOne.length; index++) 
+    { 
+        // If at least one required box is checked, disabled becomes false
+        // When it becomes false, it stays false
+        // Boolean logic, yo
+        disabled = disabled && !(atLeastOne[index].checked);
+    } 
+    
+    // Disable the submit button based on results
+    document.getElementById("btnGo").disabled = disabled; 
+}
+
+// Get all the checkboxes on the page
+var inputs = document.querySelectorAll("input[requiredAtLeastOne]");
+
+// Add an event listener to each which calls the enableDisable function
+for (var index = 0; index < inputs.length; index++) 
+{ 
+    // Trust me, you need to do it this way
+    inputs[index].addEventListener("click", function() { enableDisable(); });
+}
+</script>
+
+<?php
 include("tailHTML.html");
 
 ?>
+

--- a/Results2.php
+++ b/Results2.php
@@ -126,19 +126,14 @@ for($num = 0; $num < count($arraySelectedAdvisors); $num++) {
         foreach ($chkbIndividual as $checkObj) {
 
             if($checkObj == $major) {
-                print("Individual Advising: <input type='checkbox' style='height: 20px; width: 20px;' value='True' checked>"); 
-
+                
                 # Minimum date on picker is now the date calculated in $twoDaysLater
-                print("<input type='date' min = '".$twoDaysLater."' name = 'dateApptI[]' required><br>");
+                print("Individual Advising: <input type='date' min = '".$twoDaysLater."' name = 'dateApptI[]' required><br>"); 
+
                 $count++;
             }
 
         }
-    }
-
-    # No matches
-    if ($count == 0) {
-        print("Individual Advising: <input type='checkbox' style='height: 20px; width: 20px;' value='True'><br>"); 
     }
 
     # Print out a date picker for group advising if applicable
@@ -147,18 +142,11 @@ for($num = 0; $num < count($arraySelectedAdvisors); $num++) {
         foreach ($chkbGroup as $checkObj) {
             if ($checkObj == $major) {
 
-                print("Group Advising: <input type='checkbox' style='height: 20px; width: 20px;' value='True' checked>"); 
+                print("Group Advising: <input type='date' min = '".$twoDaysLater."' name = 'dateApptG[]' required><br>"); 
 
-                # Again, minimum date is date calculated in $twoDaysLater
-                print("<input type='date' min = '".$twoDaysLater."' name = 'dateApptG[]' required><br>");
                 $count++;
             }
         }
-    }
-
-    # No matches
-    if ($count == 0) {
-        print("Group Advising: <input type='checkbox' style='height: 20px; width: 20px;' value='True'><br>"); 
     }
 
     print("</div>");

--- a/Utilities.php
+++ b/Utilities.php
@@ -76,7 +76,7 @@ function printAdvisors($currChoice) {
 		print("<a href='mailto:$email'>$email</a><br>" . $row2['Position'] . "<br>"); 
 		$name = $row2['Name'];
 		$temp = $name . ", " . $currChoice;
-		print("Select: <input type='checkbox' name='arraySelectedAdvisors[]' style='height: 20px; width: 20px;' value='$temp'><br><br>"); 
+		print("Select: <input type='checkbox' name='arraySelectedAdvisors[]' style='height: 20px; width: 20px;' value='$temp' checked><br><br>"); 
 	}
 
 	#grabs from first query into Department Database and prints any additional info


### PR DESCRIPTION
This fixes issue #15 . Highlights of the changes in this branch are:
- Change `printAdvisors($currChoice)` in Utilities.php to have advisor boxes checked by default
- Add an ID of `btnGo` to the submit button in Results1.php
- Submit button in Results1.php now disabled by default
- Add a `requiredAtLeastOne` attribute to all individual advising and group advising checkboxes in Results1.php
- Add a script to the end of Results1.php to change the disabled state of the submit button when individual advising or group advising checkboxes are checked

P.S. It's really hard to test my code when the directory structure is wrong and I don't have your CommonMethods.php so I can access the database @jadedtdt 
