### PR TITLE
group uses student ID to filter now

### DIFF
--- a/students/Results3.php
+++ b/students/Results3.php
@@ -218,25 +218,32 @@ for($num = 0; $num < count($arraySelectedAdvisors); $num++) {
 	{ 
 		print("Group Appointments<br>");
 		print("<input type='radio' name='radiogrpID".$advID."' value='' checked>No selection<br>");
-		$sql = "select * from `GroupAppointments` where `Advisors` LIKE '%".$name."%' and `Signups` NOT LIKE '%".$tfNameF." ".$tfNameL."%'";
+		$sql = "select * from `GroupAppointments` where `Advisors` LIKE '%".$name."%'";
 		$rs = $COMMON-> executeQuery($sql, $_SERVER["SCRIPT_NAME"]);
 		while($row = mysql_fetch_array($rs))
 		{
+			
 			$max=$row['Capacity'];
 			$datetime=$row['Date/Time'];
-			$printdate=date("l, F jS, g:iA",strtotime($datetime));
-			
-			$students=$row['Signups'];
-			$numstudents=0;
-			if($students!=NULL){
-			$numstudents=substr_count($students, ",")+1;
-			}
-			if($numstudents>=$max)
-			{print("FULL - ".$printdate."<br>");}
-			else
+			$groupID=$row['ID'];
+			$sqlcheck = "select * from `Appointment` where `AppointmentID` = '$groupID' and `Student ID` ='$tfId'";
+			$rscheck = $COMMON-> executeQuery($sqlcheck, $_SERVER["SCRIPT_NAME"]);
+			if(!($row2 = mysql_fetch_array($rscheck)))
 			{
-				print("<input type='radio' name='radiogrpID".$advID."' value='".$datetime."'>");
-				print(($max-$numstudents)." seats left - ".$printdate."<br>");
+				$printdate=date("l, F jS, g:iA",strtotime($datetime));
+				
+				$students=$row['Signups'];
+				$numstudents=0;
+				if($students!=NULL){
+				$numstudents=substr_count($students, ",")+1;
+				}
+				if($numstudents>=$max)
+				{print("FULL - ".$printdate."<br>");}
+				else
+				{
+					print("<input type='radio' name='radiogrpID".$advID."' value='".$datetime."'>");
+					print(($max-$numstudents)." seats left - ".$printdate."<br>");
+				}
 			}
 		}
 		


### PR DESCRIPTION
when filtering for group appointments, instead of filtering by group appointments that don't contain the student's name in GroupAppointments, it now checks Appointments for matches with the same student ID and group appointment ID and excludes those appointments if so.

There shouldn't be anything visually different but:

http://userpages.umbc.edu/~tbrandt1/CMSC331/Project2/students/
